### PR TITLE
Implemented variance and standard_deviation

### DIFF
--- a/lib/descriptive_statistics.ex
+++ b/lib/descriptive_statistics.ex
@@ -41,4 +41,15 @@ defmodule DescriptiveStatistics do
       Enum.at(sorted, half)
     end
   end
+
+  def variance([]), do: nil
+  def variance ary do
+    mean = mean(ary)
+    sum(Enum.map(ary, &((mean - &1) * (mean - &1)))) /  __MODULE__.length(ary)
+  end
+
+  def standard_deviation([]), do: nil
+  def standard_deviation(ary) do
+    :math.sqrt(variance(ary))
+  end
 end

--- a/test/descriptive_statistics_test.exs
+++ b/test/descriptive_statistics_test.exs
@@ -36,4 +36,14 @@ defmodule DescriptiveStatisticsTest do
     assert 2.5 == DescriptiveStatistics.median([1,2,3,6])
     assert 2   == DescriptiveStatistics.median([1,2,2,6])
   end
+
+  test "#variance" do
+    assert 0 == DescriptiveStatistics.variance([1,1,1,1])
+    assert 8.25 == DescriptiveStatistics.variance([1,2,3,4,5,6,7,8,9,10])
+  end
+
+  test "#standard_deviation" do
+    assert 0 == DescriptiveStatistics.standard_deviation([1,1,1,1])
+    assert 2.8722813232690143 == DescriptiveStatistics.standard_deviation([1,2,3,4,5,6,7,8,9,10])
+  end
 end


### PR DESCRIPTION
Maybe it'd be good to remove DescriptiveStatistics length since we can always use length anyway and we wouldn't need to do `__MODULE__` inside the module
